### PR TITLE
Bug fixes, cleanup, flowpath create table

### DIFF
--- a/beaker/builtin.cpp
+++ b/beaker/builtin.cpp
@@ -130,6 +130,7 @@ Builtin::get_table()
 
   Decl_seq parms =
   {
+    new Parameter_decl(get_identifier("dp"), get_opaque_type()->ref()),
     new Parameter_decl(get_identifier("id"), get_integer_type()),
     new Parameter_decl(get_identifier("key_size"), get_integer_type()),
     new Parameter_decl(get_identifier("size"), get_integer_type()),
@@ -482,12 +483,12 @@ Builtin::call_alias_bind(Expr* cxt, Expr* id1, Expr* id2, Expr* off, Expr* len)
 
 
 Expr*
-Builtin::call_create_table(Decl* d, Expr_seq const& args)
+Builtin::call_create_table(Decl* d, Expr* dp, Expr* id, Expr* key_size, Expr* entry_size, Expr* kind)
 {
   Function_decl* fn = builtin_fn.find(__get_table)->second;
   assert(fn);
 
-  Create_table* e = new Create_table(decl_id(fn), args);
+  Create_table* e = new Create_table(decl_id(fn), { dp, id, key_size, entry_size, kind});
   e->table_ = d;
 
   return e;

--- a/beaker/builtin.cpp
+++ b/beaker/builtin.cpp
@@ -34,7 +34,7 @@ Builtin::bind_header()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -61,7 +61,7 @@ Builtin::bind_field()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -89,7 +89,7 @@ Builtin::alias_bind()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -114,7 +114,7 @@ Builtin::advance()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -141,7 +141,7 @@ Builtin::get_table()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -177,7 +177,7 @@ Builtin::add_flow()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -210,7 +210,7 @@ Builtin::add_miss()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -236,7 +236,7 @@ Builtin::gather()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -267,7 +267,7 @@ Builtin::match()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -287,7 +287,7 @@ Builtin::get_port()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, {}, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
   return fn;
 }
 
@@ -308,7 +308,7 @@ Builtin::drop()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, {}, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
 
   return fn;
 }
@@ -332,7 +332,7 @@ Builtin::output()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, {}, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
 
   return fn;
 }
@@ -360,7 +360,7 @@ Builtin::set_field()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, {}, block({}));
 
-  fn->declare_ = true;
+  fn->spec_ |= foreign_spec;
 
   return fn;
 }

--- a/beaker/builtin.cpp
+++ b/beaker/builtin.cpp
@@ -220,9 +220,9 @@ Function_decl*
 Builtin::gather()
 {
   Symbol const* fn_name = get_identifier(__gather);
-  Type const* cxt_ref = get_reference_type(get_context_type());
+  Type const* cxt_ref = get_context_type()->ref();
   Type const* int_type = get_integer_type();
-  Type const* key_type = get_reference_type(get_key_type());
+  Type const* key_type = get_key_type()->ref();
 
   Decl_seq parms =
   {
@@ -248,18 +248,21 @@ Builtin::match()
   // so what the actual table type is doesnt matter as long
   // as it is a table type.
   Type const* ret_type = get_void_type();
-  Type const* tbl_ref = get_reference_type(get_table_type({}, {}));
-  Type const* cxt_ref = get_reference_type(get_context_type());
+  Type const* tbl_ref = get_table_type({}, {})->ref();
+  Type const* cxt_ref = get_context_type()->ref();
   Symbol const* fn_name = get_identifier(__match);
 
   Decl_seq parms =
   {
     new Parameter_decl(get_identifier(__context), cxt_ref),
-    new Parameter_decl(get_identifier(__key), get_reference_type(get_key_type())),
     new Parameter_decl(get_identifier(__table), tbl_ref),
+    new Parameter_decl(get_identifier("n"), get_integer_type()) // number of fields
   };
 
-  Type const* fn_type = get_function_type(parms, ret_type);
+  Type_seq parm_t = { cxt_ref, tbl_ref };
+
+  // C Variadic Function
+  Type const* fn_type = get_function_type(parm_t, ret_type, true);
 
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, parms, block({}));
@@ -297,7 +300,7 @@ Builtin::drop()
   Type const* void_type = get_void_type();
 
   Decl_seq parms {
-    new Parameter_decl(get_identifier("cxt"), get_reference_type(get_context_type()))
+    new Parameter_decl(get_identifier("cxt"), get_context_type()->ref())
   };
 
   Type const* fn_type = get_function_type(parms, void_type);
@@ -317,10 +320,10 @@ Builtin::output()
   Symbol const* fn_name = get_identifier(__output);
 
   Type const* void_type = get_void_type();
-  Type const* port_type = get_reference_type(get_port_type());
+  Type const* port_type = get_port_type()->ref();
 
   Decl_seq parms {
-    new Parameter_decl(get_identifier("cxt"), get_reference_type(get_context_type())),
+    new Parameter_decl(get_identifier("cxt"), get_context_type()->ref()),
     new Parameter_decl(get_identifier("port"), port_type)
   };
 
@@ -552,10 +555,13 @@ Builtin::call_gather(Expr* cxt, Expr_seq const& var_args)
 
 
 Expr*
-Builtin::call_match(Expr_seq const& args)
+Builtin::call_match(Expr* cxt, Expr* tbl, Expr* n, Expr_seq const& var_args)
 {
   Function_decl* fn = builtin_fn.find(__match)->second;
   assert(fn);
+
+  Expr_seq args { cxt, tbl, n };
+  args.insert(args.end(), var_args.begin(), var_args.end());
 
   return new Match(decl_id(fn), args);
 }

--- a/beaker/builtin.hpp
+++ b/beaker/builtin.hpp
@@ -21,12 +21,12 @@ constexpr char const* __get_port     = "fp_get_port";
 constexpr char const* __gather       = "fp_gather";
 constexpr char const* __output       = "fp_output_port";
 constexpr char const* __drop         = "fp_drop";
-constexpr char const* __context      = "__cxt__";
-constexpr char const* __header       = "__header__";
-constexpr char const* __table        = "__table__";
-constexpr char const* __key          = "__key__";
-constexpr char const* __drop_port    = "__drop";
-constexpr char const* __flood_port   = "__flood";
+constexpr char const* __context      = "_cxt_";
+constexpr char const* __header       = "_header_";
+constexpr char const* __table        = "_table_";
+constexpr char const* __key          = "_key_";
+constexpr char const* __drop_port    = "_drop_";
+constexpr char const* __flood_port   = "_flood_";
 
 // runtime interface functions
 constexpr char const* __load         = "config";
@@ -250,7 +250,7 @@ struct Builtin
   Expr* call_create_table(Decl*, Expr_seq const& args);
   Expr* call_add_flow(Expr_seq const& args);
   Expr* call_add_miss(Expr*, Expr*);
-  Expr* call_match(Expr_seq const& args);
+  Expr* call_match(Expr*, Expr*, Expr*, Expr_seq const& var_args);
   Expr* call_get_port(Decl*, Expr_seq const& args);
   Expr* call_gather(Expr* cxt, Expr_seq const& var_args);
   Expr* call_drop(Expr* cxt);

--- a/beaker/builtin.hpp
+++ b/beaker/builtin.hpp
@@ -20,6 +20,7 @@ constexpr char const* __set_field    = "fp_set_field";
 constexpr char const* __get_port     = "fp_get_port";
 constexpr char const* __gather       = "fp_gather";
 constexpr char const* __output       = "fp_output_port";
+constexpr char const* __dataplane    = "fp_dataplane";
 constexpr char const* __drop         = "fp_drop";
 constexpr char const* __context      = "_cxt_";
 constexpr char const* __header       = "_header_";

--- a/beaker/builtin.hpp
+++ b/beaker/builtin.hpp
@@ -12,7 +12,7 @@ constexpr char const* __bind_header  = "fp_bind_header";
 constexpr char const* __bind_field   = "fp_bind_field";
 constexpr char const* __alias_bind   = "fp_alias_bind";
 constexpr char const* __advance      = "fp_advance";
-constexpr char const* __get_table    = "fp_get_table";
+constexpr char const* __get_table    = "fp_create_table";
 constexpr char const* __add_flow     = "fp_add_flow";
 constexpr char const* __add_miss     = "fp_add_miss";
 constexpr char const* __match        = "fp_goto_table";
@@ -248,7 +248,7 @@ struct Builtin
   Expr* call_bind_header(Expr*, Expr*, Expr*);
   Expr* call_alias_bind(Expr*, Expr*, Expr*, Expr*, Expr*);
   Expr* call_advance(Expr_seq const& args);
-  Expr* call_create_table(Decl*, Expr_seq const& args);
+  Expr* call_create_table(Decl*, Expr*, Expr*, Expr*, Expr*, Expr*);
   Expr* call_add_flow(Expr_seq const& args);
   Expr* call_add_miss(Expr*, Expr*);
   Expr* call_match(Expr*, Expr*, Expr*, Expr_seq const& var_args);

--- a/beaker/decl.cpp
+++ b/beaker/decl.cpp
@@ -62,7 +62,7 @@ Record_decl::is_empty() const
   if (Record_decl const* b = base_declaration())
     if (b->is_empty())
       return false;
-  
+
   // An empty base class has no fields.
   return fields_.empty();
 }
@@ -74,4 +74,13 @@ bool
 is_reference(Decl const* d)
 {
   return is<Reference_type>(d->type());
+}
+
+
+// Returns true when the declaration is declared as a reference to an opaque
+// object.
+bool
+is_opaque_reference(Decl const* d)
+{
+  return is<Reference_type>(d->type()) && is<Opaque_type>(d->type()->nonref());
 }

--- a/beaker/decl.hpp
+++ b/beaker/decl.hpp
@@ -21,11 +21,11 @@ struct Decl
   struct Mutator;
 
   Decl(Symbol const* s, Type const* t)
-    : spec_(no_spec), name_(s), type_(t), cxt_(nullptr), declare_(false)
+    : spec_(no_spec), name_(s), type_(t), cxt_(nullptr)
   { }
 
   Decl(Specifier spec, Symbol const* s, Type const* t)
-    : spec_(spec), name_(s), type_(t), cxt_(nullptr), declare_(false)
+    : spec_(spec), name_(s), type_(t), cxt_(nullptr)
   { }
 
   virtual ~Decl() { }
@@ -36,7 +36,7 @@ struct Decl
   // Declaration specifiers
   Specifier specifiers() const { return spec_; }
   bool      is_foreign() const { return spec_ & foreign_spec; }
-  bool      is_declare() const { return declare_; }
+  bool      is_extern() const { return spec_ & extern_spec; }
 
   Symbol const* name() const { return name_; }
   Type const*   type() const { return type_; }
@@ -47,7 +47,6 @@ struct Decl
   Symbol const* name_;
   Type const*   type_;
   Decl const*   cxt_;
-  bool          declare_;
 };
 
 

--- a/beaker/decl.hpp
+++ b/beaker/decl.hpp
@@ -533,6 +533,9 @@ is_pipeline_decl(Decl const* d)
 // Returns true if the declaration is a reference.
 bool is_reference(Decl const*);
 
+// Returns true if it is a reference to an opaque object.
+bool is_opaque_reference(Decl const*);
+
 
 // -------------------------------------------------------------------------- //
 //                              Generic visitors

--- a/beaker/elaborator.cpp
+++ b/beaker/elaborator.cpp
@@ -193,6 +193,7 @@ Elaborator::elaborate(Type const* t)
     Type const* operator()(Reference_type const* t) { return elab.elaborate(t); }
     Type const* operator()(Record_type const* t) { return elab.elaborate(t); }
     Type const* operator()(Void_type const* t) { return elab.elaborate(t); }
+    Type const* operator()(Opaque_type const* t) { return elab.elaborate(t); }
 
     Type const* operator()(Layout_type const* t) { return elab.elaborate(t); }
     Type const* operator()(Context_type const* t) { return elab.elaborate(t); }
@@ -312,6 +313,15 @@ Elaborator::elaborate(Record_type const* t)
 
 Type const*
 Elaborator::elaborate(Void_type const* t)
+{
+  return t;
+}
+
+
+// TODO: Make sure there are no objects of opaque type. There can only
+// be references of opaque type.
+Type const*
+Elaborator::elaborate(Opaque_type const* t)
 {
   return t;
 }

--- a/beaker/elaborator.hpp
+++ b/beaker/elaborator.hpp
@@ -72,6 +72,7 @@ public:
   Type const* elaborate(Reference_type const*);
   Type const* elaborate(Record_type const*);
   Type const* elaborate(Void_type const*);
+  Type const* elaborate(Opaque_type const*);
 
   // network specific types
   Type const* elaborate(Layout_type const*);

--- a/beaker/evaluator.cpp
+++ b/beaker/evaluator.cpp
@@ -382,7 +382,7 @@ Evaluator::eval(Demotion_conv const* e)
 
 // Return the evaluation of the integer
 // FIXME: It should be the signed/unsigned evaluation of the integer.
-// FIXME: This isn't right. There should be some explicit chage 
+// FIXME: This isn't right. There should be some explicit chage
 // of the underlying integer.
 Value
 Evaluator::eval(Sign_conv const* e)
@@ -516,6 +516,7 @@ get_value(Type const* t)
     }
 
     Value operator()(Void_type const* t) { return 0; }
+    Value operator()(Opaque_type const* t) { return 0; }
     Value operator()(Layout_type const* t) { return 0; }
     Value operator()(Context_type const* t) { return 0; }
     Value operator()(Port_type const* t) { return 0; }

--- a/beaker/gather.cpp
+++ b/beaker/gather.cpp
@@ -1,6 +1,7 @@
 #include "beaker/expr.hpp"
 #include "beaker/type.hpp"
 #include "beaker/length.hpp"
+#include "beaker/evaluator.hpp"
 
 
 Expr*
@@ -9,14 +10,14 @@ gather(Expr_seq const& subkeys)
   // maintain the largest allowable key buffer
   uint512_t buf = 0;
 
+  Evaluator ev;
+
   // maintain the position to start writing
   int pos = 0;
   for (auto subkey : subkeys) {
     // get the precision of the subkey
     int prec = precision(subkey->type());
-    // get the literal expression
-    Literal_expr* e = as<Literal_expr>(subkey);
-    Value const& val = e->value();
+    Value const& val = ev.eval(subkey);
     // FIXME: for now we're only dealing with unsigned integer values
     assert(val.is_integer());
     std::stringstream ss;

--- a/beaker/generator.cpp
+++ b/beaker/generator.cpp
@@ -374,7 +374,7 @@ Generator::gen(Decl_expr const* e)
   // Fetch the value from a reference declaration.
   Decl const* decl = bind->first;
 
-  if (is_reference(decl))
+  if (is_reference(decl) && !is_opaque_reference(decl))
     return build.CreateLoad(result);
 
   return result;

--- a/beaker/generator.cpp
+++ b/beaker/generator.cpp
@@ -1178,7 +1178,14 @@ Generator::gen(Function_decl const* d)
   if (d->is_foreign())
     return;
 
-  String name = get_name(d);
+  // If the function has external linkage, do not mangle the name.
+  String name;
+  if (d->is_extern())
+    name = d->name()->spelling();
+  else
+    name = get_name(d);
+
+
   llvm::Type* type = get_type(d->type());
 
   // Build the function.

--- a/beaker/generator.cpp
+++ b/beaker/generator.cpp
@@ -191,7 +191,7 @@ Generator::get_type(Void_type const* t)
 llvm::Type*
 Generator::get_type(Opaque_type const* t)
 {
-  static llvm::Type* opaque_type = llvm::StructType::create(cxt);
+  static llvm::Type* opaque_type = llvm::StructType::create(cxt, "Opaque");
   return opaque_type;
 }
 

--- a/beaker/generator.cpp
+++ b/beaker/generator.cpp
@@ -213,7 +213,7 @@ Generator::get_type(Context_type const* t)
 llvm::Type*
 Generator::get_type(Table_type const*)
 {
-  static llvm::Type* table_type = llvm::StructType::create(cxt, "__Table__");
+  static llvm::Type* table_type = llvm::StructType::create(cxt, "Table");
   return table_type;
 }
 
@@ -230,7 +230,7 @@ Generator::get_type(Flow_type const*)
 llvm::Type*
 Generator::get_type(Port_type const* t)
 {
-  static llvm::Type* port_type = llvm::StructType::create(cxt, "__Port__");
+  static llvm::Type* port_type = llvm::StructType::create(cxt, "Port");
   return port_type;
 }
 
@@ -239,7 +239,7 @@ Generator::get_type(Port_type const* t)
 llvm::Type*
 Generator::get_type(Key_type const* t)
 {
-  static llvm::Type* key_type = llvm::StructType::create(cxt, "__Key__");
+  static llvm::Type* key_type = llvm::StructType::create(cxt, "Key");
   return key_type;
 }
 

--- a/beaker/generator.cpp
+++ b/beaker/generator.cpp
@@ -68,6 +68,7 @@ Generator::get_type(Type const* t)
     llvm::Type* operator()(Record_type const* t) const { return g.get_type(t); }
     llvm::Type* operator()(Void_type const* t) { return g.get_type(t); }
     llvm::Type* operator()(Context_type const* t) { return g.get_type(t); }
+    llvm::Type* operator()(Opaque_type const* t) { return g.get_type(t); }
 
     // network specific types
     llvm::Type* operator()(Layout_type const* t) const { return g.get_type(t); }
@@ -184,6 +185,14 @@ llvm::Type*
 Generator::get_type(Void_type const* t)
 {
   return build.getVoidTy();
+}
+
+
+llvm::Type*
+Generator::get_type(Opaque_type const* t)
+{
+  static llvm::Type* opaque_type = llvm::StructType::create(cxt);
+  return opaque_type;
 }
 
 
@@ -1166,13 +1175,8 @@ Generator::gen(Function_decl const* d)
   // If it was a declaration only it should
   // have been captured by the first pass and no further
   // generation is necessary.
-  //
-  // NOTE: Confirm that this is right if we can make local
-  // foreign function declarations which I don't think we
-  // can.
-  if (d->is_declare()) {
+  if (d->is_foreign())
     return;
-  }
 
   String name = get_name(d);
   llvm::Type* type = get_type(d->type());
@@ -1356,7 +1360,6 @@ Generator::gen(Module_decl const* d)
 
   // Generate all top-level declarations.
   for (Decl const* d1 : d->declarations()) {
-    // std::cout << *d1 << '\n';
     gen(d1);
   }
 
@@ -1543,8 +1546,8 @@ void
 Generator::declare_global(Function_decl const* d)
 {
   // only emit a declaration of the function is marked
-  // is_declare only.
-  if (d->is_declare()) {
+  // is_foreign only.
+  if (d->is_foreign()) {
     // no mangling
     String name = d->name()->spelling();
     llvm::Type* type = get_type(d->type());

--- a/beaker/generator.hpp
+++ b/beaker/generator.hpp
@@ -60,6 +60,7 @@ struct Generator
   llvm::Type* get_type(Reference_type const*);
   llvm::Type* get_type(Record_type const*);
   llvm::Type* get_type(Void_type const*);
+  llvm::Type* get_type(Opaque_type const*);
 
   // network specific types
   llvm::Type* get_type(Layout_type const*);

--- a/beaker/length.cpp
+++ b/beaker/length.cpp
@@ -34,10 +34,8 @@ bool has_constant_length(Type const* t)
       return true;
     }
 
-    bool operator()(Void_type const* t)
-    {
-      return false;
-    }
+    bool operator()(Void_type const* t) { return false; }
+    bool operator()(Opaque_type const* t) { return false; }
 
     // network specific types
     bool operator()(Layout_type const* t)
@@ -86,6 +84,7 @@ int precision(Type const* t)
     int operator()(Flow_type const* t) { throw std::runtime_error("unsupported length"); }
     int operator()(Port_type const* t) { throw std::runtime_error("unsupported length"); }
     int operator()(Key_type const* t) { throw std::runtime_error("unsupported length"); }
+    int operator()(Opaque_type const* t) { throw std::runtime_error("unsupported length"); }
 
     // dynamic type
     // FIXME: do this right
@@ -135,6 +134,7 @@ Expr* length(Type const* t)
     Expr* operator()(Id_type const* t) { throw std::runtime_error("no length type"); }
     Expr* operator()(Function_type const* t) { throw std::runtime_error("no length type"); }
     Expr* operator()(Void_type const* t) { throw std::runtime_error("no length type"); }
+    Expr* operator()(Opaque_type const* t) { throw std::runtime_error("no length type"); }
     Expr* operator()(Context_type const* t) { throw std::runtime_error("no length type"); }
     Expr* operator()(Table_type const* t) { throw std::runtime_error("no length type"); }
     Expr* operator()(Flow_type const* t) { throw std::runtime_error("no length type"); }

--- a/beaker/less.cpp
+++ b/beaker/less.cpp
@@ -160,6 +160,7 @@ is_less(Type const* a, Type const* b)
     bool operator()(Reference_type const* a) { return is_less(a, cast<Reference_type>(b)); }
     bool operator()(Record_type const* a) { return is_less(a, cast<Record_type>(b)); }
     bool operator()(Void_type const* a) { return false; }
+    bool operator()(Opaque_type const* a) { return false; }
 
     // network specific types
     bool operator()(Layout_type const* a) { return is_less(a, cast<Layout_type>(b)); }

--- a/beaker/lower.cpp
+++ b/beaker/lower.cpp
@@ -36,7 +36,7 @@ Lowerer::load_function()
   Function_decl* load = new Function_decl(fn_name, fn_type,
                                           parms, block(load_body));
 
-  load->spec_ |= foreign_spec;
+  load->spec_ |= extern_spec;
   declare(load);
 
   return load;
@@ -74,7 +74,7 @@ Lowerer::process_function()
   Stmt_seq process_body;
   process_body.push_back(new Expression_stmt(call));
 
-  process->spec_ |= foreign_spec;
+  process->spec_ |= extern_spec;
 
   process->body_ = block(process_body);
 
@@ -98,7 +98,7 @@ Lowerer::port_number_function()
   Function_decl* fn =
     new Function_decl(fn_name, fn_type, {}, block(body));
 
-  fn->spec_ |= foreign_spec;
+  fn->spec_ |= extern_spec;
 
   return fn;
 }
@@ -388,7 +388,7 @@ Lowerer::lower_global_def(Decode_decl* d)
   // Lower the body and change the definition of the function.
   Stmt* body = lower(d->body()).back();
   fn->body_ = body;
-  fn->spec_ |= foreign_spec;
+  fn->spec_ |= extern_spec;
 
   // bind the header into the context with its id
   Layout_type const* ltype = as<Layout_type>(d->header());
@@ -437,7 +437,7 @@ Lowerer::lower_table_flows(Table_decl* d)
     // The type of all flows is fn(Context&) -> void
     Type const* type = get_function_type(parms, void_type);
     Function_decl* fn = new Function_decl(flow_name, type, parms, flow_body);
-    fn->spec_ |= foreign_spec;
+    fn->spec_ |= extern_spec;
     flow_fns.push_back(fn);
   }
 
@@ -472,7 +472,7 @@ Lowerer::lower_miss_case(Table_decl* d)
     // The type of all flows is fn(Context&) -> void
     Type const* type = get_function_type(parms, void_type);
     Function_decl* fn = new Function_decl(flow_name, type, parms, flow_body);
-    fn->spec_ |= foreign_spec;
+    fn->spec_ |= extern_spec;
 
     return fn;
   }

--- a/beaker/lower.cpp
+++ b/beaker/lower.cpp
@@ -26,7 +26,9 @@ Function_decl*
 Lowerer::load_function()
 {
   Type const* void_type = get_void_type();
-  Decl_seq parms {  };
+  Decl_seq parms {
+    new Parameter_decl(get_identifier(__dataplane), get_opaque_type()->ref())
+  };
 
   Type const* fn_type = get_function_type(parms, void_type);
   Symbol const* fn_name = get_identifier(__load);
@@ -544,6 +546,9 @@ Lowerer::lower_global_def(Table_decl* d)
   assert(ovl);
   Decl* tbl = ovl->back();
   assert(tbl);
+
+  // We need the global variable storing the dataplane pointer which is
+  // set when the config() function is called.
 
   Scope_sentinel scope(*this, d);
 

--- a/beaker/lower.hpp
+++ b/beaker/lower.hpp
@@ -81,9 +81,12 @@ struct Lowerer
   Function_decl* port_number_function();
   Function_decl* start_function();
 
+  Variable_decl* dataplane_pointer();
+
   // builtin handling
   void add_builtin_ports();
   void add_builtin_functions();
+  void add_builtin_variables();
   void add_prelude();
 
   void declare(Decl*);

--- a/beaker/mangle.cpp
+++ b/beaker/mangle.cpp
@@ -121,7 +121,7 @@ mangle(std::ostream& os, Void_type const* t)
 void
 mangle(std::ostream& os, Opaque_type const* t)
 {
-  return;
+  os << "opq";
 }
 
 

--- a/beaker/mangle.cpp
+++ b/beaker/mangle.cpp
@@ -117,6 +117,13 @@ mangle(std::ostream& os, Void_type const* t)
 }
 
 
+// This shouldn't be necessary.
+void
+mangle(std::ostream& os, Opaque_type const* t)
+{
+  return;
+}
+
 
 // network specific types
 void
@@ -181,6 +188,7 @@ mangle(std::ostream& os, Type const* t)
     void operator()(Reference_type const* t) { return mangle(os, t); }
     void operator()(Record_type const* t) { return mangle(os, t); }
     void operator()(Void_type const* t) { return mangle(os, t); }
+    void operator()(Opaque_type const* t) { return mangle(os, t); }
 
     // network specific types
     void operator()(Layout_type const* t) { return mangle(os, t); }

--- a/beaker/mangle.hpp
+++ b/beaker/mangle.hpp
@@ -25,6 +25,7 @@ void mangle(std::ostream&, Block_type const*);
 void mangle(std::ostream&, Reference_type const*);
 void mangle(std::ostream&, Record_type const*);
 void mangle(std::ostream&, Void_type const*);
+void mangle(std::ostream&, Opaque_type const*);
 
 // network specific types
 void mangle(std::ostream&, Layout_type const*);

--- a/beaker/parser.cpp
+++ b/beaker/parser.cpp
@@ -922,7 +922,6 @@ Parser::flow_decl(Token tok)
   Expr_seq keys;
   while (lookahead() != rbrace_tok) {
     Expr* k = expr();
-    std::cout << "KEY EXPR: " << *k << '\n';
     if (k)
       keys.push_back(k);
 

--- a/beaker/parser.cpp
+++ b/beaker/parser.cpp
@@ -922,6 +922,7 @@ Parser::flow_decl(Token tok)
   Expr_seq keys;
   while (lookahead() != rbrace_tok) {
     Expr* k = expr();
+    std::cout << "KEY EXPR: " << *k << '\n';
     if (k)
       keys.push_back(k);
 

--- a/beaker/prelude.hpp
+++ b/beaker/prelude.hpp
@@ -93,6 +93,7 @@ struct Port_type;
 struct Void_type;
 struct Context_type;
 struct Key_type;
+struct Opaque_type;
 
 struct Decl;
 struct Record_decl;

--- a/beaker/print.cpp
+++ b/beaker/print.cpp
@@ -390,6 +390,7 @@ operator<<(std::ostream& os, Type const& t)
     void operator()(Reference_type const* t) { os << *t; }
     void operator()(Record_type const* t) { os << *t; }
     void operator()(Void_type const* t) { os << *t; }
+    void operator()(Opaque_type const* t) { os << *t; }
 
     // network specific types
     void operator()(Layout_type const* t) { os << *t; }
@@ -485,6 +486,13 @@ std::ostream&
 operator<<(std::ostream& os, Void_type const&)
 {
   return os << "void";
+}
+
+
+std::ostream&
+operator<<(std::ostream& os, Opaque_type const&)
+{
+  return os << "opaque";
 }
 
 

--- a/beaker/print.hpp
+++ b/beaker/print.hpp
@@ -59,6 +59,8 @@ std::ostream& operator<<(std::ostream&, Array_type const&);
 std::ostream& operator<<(std::ostream&, Reference_type const&);
 std::ostream& operator<<(std::ostream&, Record_type const&);
 std::ostream& operator<<(std::ostream&, Void_type const&);
+std::ostream& operator<<(std::ostream&, Opaque_type const&);
+
 
 // network specific types
 std::ostream& operator<<(std::ostream&, Layout_type const&);

--- a/beaker/specifier.hpp
+++ b/beaker/specifier.hpp
@@ -42,6 +42,7 @@ enum Specifier
   //
   // TODO: Support foreign language linkage for other
   // other languages?
+  extern_spec = 1 << 9,
   foreign_spec = 1 << 10,
   meta_spec = 1 << 11,
 };

--- a/beaker/stmt.hpp
+++ b/beaker/stmt.hpp
@@ -134,6 +134,19 @@ struct Return_stmt : Stmt
 };
 
 
+// An explicit return 'void' statement.
+//
+// NOTE: This node is currently not supported or
+// exposed as surface level syntax but can be generated internally by the
+// compiler. This translates to an immediate return from the function and
+// can only occur in functions that return void.
+struct Return_void_stmt : Stmt
+{
+  // void accept(Visitor& v) const { return v.visit(this); }
+  // void accept(Mutator& v)       { return v.visit(this); }
+};
+
+
 // A statement of the form:
 //
 //    if (e) s

--- a/beaker/test/steve/decode-3.stv
+++ b/beaker/test/steve/decode-3.stv
@@ -22,9 +22,9 @@ decoder eth_d2(eth)
 	goto t1;
 }
 
-exact_table t1(eth::dst)
+exact_table t1(eth::dst, eth::type)
 {
-{ 0x12_34_56_78_90_ab } -> { output p1; };
-{ 0xab_12_34_56_78_90 } -> { output p2; };
+{ 0x12_34_56_78_90_ab, 800 } -> { output p1; };
+{ 0xab_12_34_56_78_90, 800 } -> { output p2; };
 miss -> { drop; };
 }

--- a/beaker/test/steve/table-1.stv
+++ b/beaker/test/steve/table-1.stv
@@ -5,6 +5,12 @@ layout eth
 	type : int;
 }
 
+decoder start eth_d(eth)
+{
+	extract eth::src;
+	extract eth::dst;
+	goto t1;
+}
 
 exact_table t1(eth::src, eth::dst)
 {

--- a/beaker/type.cpp
+++ b/beaker/type.cpp
@@ -196,6 +196,15 @@ get_void_type()
   return &t;
 }
 
+
+Type const*
+get_opaque_type()
+{
+  static Opaque_type t;
+  return &t; 
+}
+
+
 // ------------------------------------------------------------ //
 //        Network specific types
 


### PR DESCRIPTION
Fixed lingo broken version.
Fixed bugs related to forming keys for initializing flow entries.
Changed fp_create_table code generation to be compliant with current working version of flowpath.
Added opaque type for convenience.
Removed legacy code from prior steve version that's no longer necessary.
